### PR TITLE
feat: add multi-board GitHub Projects screen and APIs

### DIFF
--- a/app/api/projects/[owner]/[number]/route.ts
+++ b/app/api/projects/[owner]/[number]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { auth } from "@/lib/auth"
+import { fetchGitHubProjectBoard } from "@/lib/github-projects"
+
+const paramsSchema = z.object({
+  owner: z.string().trim().min(1),
+  number: z.coerce.number().int().positive(),
+})
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ owner: string; number: string }> }
+) {
+  try {
+    const session = await auth()
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const resolvedParams = await context.params
+    const { owner, number } = paramsSchema.parse(resolvedParams)
+
+    const board = await fetchGitHubProjectBoard(session.accessToken, { owner, number })
+
+    return NextResponse.json({ board })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid board route parameters", details: error.issues }, { status: 400 })
+    }
+
+    const message = error instanceof Error ? error.message : "Failed to fetch project board"
+    const status = message.toLowerCase().includes("access") || message.toLowerCase().includes("not found") ? 404 : 500
+
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { auth } from "@/lib/auth"
+import { db } from "@/lib/db"
+import { userPreferences } from "@/drizzle/schema"
+import { eq } from "drizzle-orm"
+import {
+  fetchGitHubProjectBoard,
+  normalizePinnedProjects,
+  parseGitHubProjectUrl,
+  pinnedProjectSchema,
+} from "@/lib/github-projects"
+
+const MAX_PINNED_PROJECTS = 10
+
+const addProjectSchema = z.object({
+  action: z.literal("add"),
+  url: z.string().url(),
+})
+
+const removeProjectSchema = z.object({
+  action: z.literal("remove"),
+  project: pinnedProjectSchema,
+})
+
+const updateProjectsSchema = z.union([addProjectSchema, removeProjectSchema])
+
+export async function GET() {
+  try {
+    const session = await auth()
+    if (!session?.user?.id || !session.accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const prefs = await db.query.userPreferences.findFirst({
+      where: eq(userPreferences.userId, session.user.id),
+    })
+
+    const savedBoards = normalizePinnedProjects(prefs?.pinnedProjects)
+
+    if (savedBoards.length === 0) {
+      return NextResponse.json({ boards: [] })
+    }
+
+    const boards = await Promise.all(
+      savedBoards.map(async (board) => {
+        try {
+          const data = await fetchGitHubProjectBoard(session.accessToken!, board)
+          const lastUpdatedAt = data.items.reduce<string | null>((latest, item) => {
+            if (!item.updatedAt) return latest
+            if (!latest) return item.updatedAt
+            return new Date(item.updatedAt).getTime() > new Date(latest).getTime() ? item.updatedAt : latest
+          }, null)
+
+          return {
+            owner: data.owner,
+            number: data.number,
+            ownerType: data.ownerType,
+            title: data.title,
+            url: data.url,
+            stats: data.stats,
+            lastUpdatedAt,
+            hasAccess: true,
+            error: null,
+          }
+        } catch (error) {
+          return {
+            owner: board.owner,
+            number: board.number,
+            ownerType: board.ownerType,
+            title: `${board.owner} / Project ${board.number}`,
+            url: `https://github.com/${board.ownerType === "org" ? "orgs" : "users"}/${board.owner}/projects/${board.number}`,
+            stats: {
+              total: 0,
+              pending: 0,
+              assignedToViewer: 0,
+              done: 0,
+            },
+            lastUpdatedAt: null,
+            hasAccess: false,
+            error: error instanceof Error ? error.message : "Unable to fetch board data.",
+          }
+        }
+      })
+    )
+
+    return NextResponse.json({ boards })
+  } catch (error) {
+    console.error("Error fetching saved project boards:", error)
+    return NextResponse.json({ error: "Failed to fetch saved project boards" }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const payload = await req.json()
+    const parsed = updateProjectsSchema.parse(payload)
+
+    const prefs = await db.query.userPreferences.findFirst({
+      where: eq(userPreferences.userId, session.user.id),
+    })
+
+    const currentBoards = normalizePinnedProjects(prefs?.pinnedProjects)
+    let nextBoards = currentBoards
+
+    if (parsed.action === "add") {
+      const board = parseGitHubProjectUrl(parsed.url)
+      const key = `${board.owner.toLowerCase()}#${board.number}`
+      const withoutDuplicate = currentBoards.filter((item) => `${item.owner.toLowerCase()}#${item.number}` !== key)
+      nextBoards = [board, ...withoutDuplicate].slice(0, MAX_PINNED_PROJECTS)
+    } else {
+      const target = `${parsed.project.owner.toLowerCase()}#${parsed.project.number}`
+      nextBoards = currentBoards.filter((item) => `${item.owner.toLowerCase()}#${item.number}` !== target)
+    }
+
+    if (prefs) {
+      await db
+        .update(userPreferences)
+        .set({
+          pinnedProjects: nextBoards,
+          updatedAt: new Date(),
+        })
+        .where(eq(userPreferences.userId, session.user.id))
+    } else {
+      await db.insert(userPreferences).values({
+        userId: session.user.id,
+        pinnedProjects: nextBoards,
+      })
+    }
+
+    return NextResponse.json({ pinnedProjects: nextBoards })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid request data", details: error.issues }, { status: 400 })
+    }
+
+    if (error instanceof Error && error.message.includes("project URL")) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
+    console.error("Error updating saved project boards:", error)
+    return NextResponse.json({ error: "Failed to update saved project boards" }, { status: 500 })
+  }
+}

--- a/app/projects/[owner]/[number]/page.tsx
+++ b/app/projects/[owner]/[number]/page.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useMemo, useState } from "react"
+import { useParams } from "next/navigation"
+import { useSession } from "next-auth/react"
+import { IconLoader2, IconRefresh, IconArrowLeft, IconExternalLink } from "@tabler/icons-react"
+import { TopNav } from "@/components/home/top-nav"
+import { Button } from "@/components/ui/button"
+import type { ProjectBoard, ProjectBoardItem } from "@/types/projects"
+
+type ItemFilter = "all" | "pending" | "assigned"
+
+interface BoardResponse {
+  board: ProjectBoard
+}
+
+export default function ProjectBoardPage() {
+  const { data: session, status } = useSession()
+  const params = useParams<{ owner: string; number: string }>()
+  const owner = params?.owner || ""
+  const number = params?.number || ""
+
+  const [board, setBoard] = useState<ProjectBoard | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [filter, setFilter] = useState<ItemFilter>("all")
+
+  useEffect(() => {
+    if (!session || !owner || !number) return
+
+    let ignore = false
+    const fetchBoard = async () => {
+      setIsLoading(true)
+      setError("")
+
+      try {
+        const response = await fetch(`/api/projects/${encodeURIComponent(owner)}/${number}`)
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null)
+          throw new Error(payload?.error || "Failed to fetch board")
+        }
+
+        const payload: BoardResponse = await response.json()
+        if (!ignore) {
+          setBoard(payload.board)
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err instanceof Error ? err.message : "Failed to fetch board")
+          setBoard(null)
+        }
+      } finally {
+        if (!ignore) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void fetchBoard()
+
+    return () => {
+      ignore = true
+    }
+  }, [session, owner, number])
+
+  const refreshBoard = async () => {
+    if (!owner || !number) return
+
+    setIsLoading(true)
+    setError("")
+    try {
+      const response = await fetch(`/api/projects/${encodeURIComponent(owner)}/${number}`)
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        throw new Error(payload?.error || "Failed to fetch board")
+      }
+
+      const payload: BoardResponse = await response.json()
+      setBoard(payload.board)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch board")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const filteredItems = useMemo(() => {
+    if (!board) return []
+
+    if (filter === "pending") {
+      return board.items.filter((item) => item.isPending)
+    }
+    if (filter === "assigned") {
+      return board.items.filter((item) => item.isAssignedToViewer)
+    }
+    return board.items
+  }, [board, filter])
+
+  const groupedByStatus = useMemo(() => {
+    const groups = new Map<string, ProjectBoardItem[]>()
+
+    for (const item of filteredItems) {
+      const status = item.status || "No status"
+      if (!groups.has(status)) {
+        groups.set(status, [])
+      }
+      groups.get(status)!.push(item)
+    }
+
+    return Array.from(groups.entries())
+      .map(([status, items]) => ({ status, items }))
+      .sort((a, b) => b.items.length - a.items.length)
+  }, [filteredItems])
+
+  if (status === "loading" || (isLoading && !board && !error)) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <IconLoader2 className="h-8 w-8 animate-spin text-white/50" />
+      </div>
+    )
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center px-6">
+        <div className="max-w-md text-center">
+          <h1 className="text-2xl font-semibold">Sign in required</h1>
+          <p className="mt-2 text-white/60">Please sign in to view project boards.</p>
+          <Link href="/" className="mt-4 inline-flex text-white underline hover:text-white/80">
+            Go back home
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white selection:bg-white selection:text-black overflow-x-hidden">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 py-8 md:py-12 flex flex-col items-center">
+        <TopNav session={session} />
+
+        <section className="w-full">
+          <div className="flex items-center justify-between gap-3">
+            <Link href="/projects" className="inline-flex items-center gap-2 text-sm text-white/70 hover:text-white">
+              <IconArrowLeft className="h-4 w-4" />
+              All boards
+            </Link>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={refreshBoard}
+              disabled={isLoading}
+              className="border-white/20 bg-white/10 text-white hover:bg-white/20 cursor-pointer"
+            >
+              {isLoading ? <IconLoader2 className="mr-2 h-4 w-4 animate-spin" /> : <IconRefresh className="mr-2 h-4 w-4" />}
+              Refresh
+            </Button>
+          </div>
+
+          {board && (
+            <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-5">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h1 className="text-3xl font-extrabold tracking-tight">{board.title}</h1>
+                  <p className="mt-1 text-sm font-mono text-white/50">{board.owner} / #{board.number}</p>
+                </div>
+                <a href={board.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-sm text-white/75 hover:text-white">
+                  View on GitHub
+                  <IconExternalLink className="h-4 w-4" />
+                </a>
+              </div>
+
+              <div className="mt-4 grid gap-2 sm:grid-cols-4">
+                <Metric label="Total" value={board.stats.total} />
+                <Metric label="Pending" value={board.stats.pending} />
+                <Metric label="Assigned to me" value={board.stats.assignedToViewer} />
+                <Metric label="Done" value={board.stats.done} />
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <FilterButton label="All" active={filter === "all"} onClick={() => setFilter("all")} />
+                <FilterButton label="Pending" active={filter === "pending"} onClick={() => setFilter("pending")} />
+                <FilterButton label="Assigned to me" active={filter === "assigned"} onClick={() => setFilter("assigned")} />
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>
+          )}
+
+          {board && groupedByStatus.length === 0 && !isLoading && (
+            <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-8 text-center text-white/60">
+              No items match this filter.
+            </div>
+          )}
+
+          {groupedByStatus.length > 0 && (
+            <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+              {groupedByStatus.map((group) => (
+                <section key={group.status} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
+                    <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">{group.status}</h2>
+                    <span className="text-xs text-white/50">{group.items.length}</span>
+                  </div>
+                  <div className="mt-3 space-y-2">
+                    {group.items.map((item) => (
+                      <article key={item.id} className="rounded-lg border border-white/10 bg-black/25 p-3">
+                        <a href={item.url} target="_blank" rel="noreferrer" className="text-sm font-medium text-white hover:text-white/85">
+                          {item.title}
+                        </a>
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-white/50">
+                          <span>{item.contentType === "pull_request" ? "PR" : item.contentType === "issue" ? "Issue" : "Draft"}</span>
+                          {item.repoFullName ? <span>{item.repoFullName}</span> : null}
+                          {item.state ? <span>{item.state.toLowerCase()}</span> : null}
+                          {item.updatedAt ? <span>{new Date(item.updatedAt).toLocaleDateString()}</span> : null}
+                        </div>
+                        {item.assignees.length > 0 && (
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            {item.assignees.map((assignee) => (
+                              <span key={assignee.login} className="inline-flex items-center gap-1 rounded-md border border-white/15 bg-white/10 px-2 py-0.5 text-[11px] text-white/80">
+                                @{assignee.login}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/25 px-3 py-2">
+      <p className="text-xs text-white/50">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-white">{value}</p>
+    </div>
+  )
+}
+
+function FilterButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex rounded-md border px-3 py-1 text-xs transition-colors cursor-pointer ${
+        active ? "border-white/30 bg-white/20 text-white" : "border-white/10 bg-white/5 text-white/65 hover:bg-white/10 hover:text-white"
+      }`}
+    >
+      {label}
+    </button>
+  )
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,245 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useState } from "react"
+import { useSession } from "next-auth/react"
+import { IconLoader2, IconRefresh, IconAlertCircle, IconExternalLink } from "@tabler/icons-react"
+import { TopNav } from "@/components/home/top-nav"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { SavedProjectBoardCard } from "@/types/projects"
+
+interface BoardsResponse {
+  boards: SavedProjectBoardCard[]
+}
+
+export default function ProjectsPage() {
+  const { data: session, status } = useSession()
+  const [boards, setBoards] = useState<SavedProjectBoardCard[]>([])
+  const [projectUrl, setProjectUrl] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState("")
+
+  const fetchBoards = async () => {
+    setIsLoading(true)
+    setError("")
+
+    try {
+      const response = await fetch("/api/projects")
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        throw new Error(payload?.error || "Failed to fetch boards")
+      }
+
+      const payload: BoardsResponse = await response.json()
+      setBoards(payload.boards || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch boards")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!session) return
+    void fetchBoards()
+  }, [session])
+
+  const addBoard = async () => {
+    if (!projectUrl.trim()) return
+
+    setIsSaving(true)
+    setError("")
+    try {
+      const response = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "add", url: projectUrl.trim() }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        throw new Error(payload?.error || "Failed to add board")
+      }
+
+      setProjectUrl("")
+      await fetchBoards()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add board")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const removeBoard = async (board: Pick<SavedProjectBoardCard, "owner" | "number" | "ownerType">) => {
+    setIsSaving(true)
+    setError("")
+
+    try {
+      const response = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "remove",
+          project: {
+            owner: board.owner,
+            number: board.number,
+            ownerType: board.ownerType,
+          },
+        }),
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        throw new Error(payload?.error || "Failed to remove board")
+      }
+
+      await fetchBoards()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove board")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <IconLoader2 className="h-8 w-8 animate-spin text-white/50" />
+      </div>
+    )
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center px-6">
+        <div className="max-w-md text-center">
+          <h1 className="text-2xl font-semibold">Sign in required</h1>
+          <p className="mt-2 text-white/60">Please sign in to manage and view GitHub project boards.</p>
+          <Link href="/" className="mt-4 inline-flex text-white underline hover:text-white/80">
+            Go back home
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white selection:bg-white selection:text-black overflow-x-hidden">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 py-8 md:py-12 flex flex-col items-center">
+        <TopNav session={session} />
+
+        <section className="w-full max-w-5xl">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-4xl font-extrabold tracking-tight">Project Boards</h1>
+              <p className="mt-2 text-white/60">Add multiple GitHub Project URLs and track pending or assigned work from one place.</p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={fetchBoards}
+              disabled={isLoading}
+              className="border-white/20 bg-white/10 text-white hover:bg-white/20 cursor-pointer"
+            >
+              {isLoading ? <IconLoader2 className="mr-2 h-4 w-4 animate-spin" /> : <IconRefresh className="mr-2 h-4 w-4" />}
+              Refresh
+            </Button>
+          </div>
+
+          <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <label className="text-sm text-white/80">Add board URL</label>
+            <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+              <Input
+                placeholder="https://github.com/users/<owner>/projects/<number>"
+                value={projectUrl}
+                onChange={(event) => setProjectUrl(event.target.value)}
+                className="font-mono text-sm bg-white/10 border-white/10 text-white placeholder:text-white/40 rounded-xl"
+              />
+              <Button
+                type="button"
+                onClick={addBoard}
+                disabled={isSaving || !projectUrl.trim()}
+                className="bg-white text-black hover:bg-white/90 cursor-pointer"
+              >
+                {isSaving ? <IconLoader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                Add board
+              </Button>
+            </div>
+            <p className="mt-2 text-xs text-white/45">Supports both user and organization boards.</p>
+          </div>
+
+          {error && (
+            <Alert variant="destructive" className="mt-4 border-red-400/35 bg-red-500/15 text-red-100">
+              <IconAlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {boards.map((board) => (
+              <article key={`${board.owner}-${board.number}`} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <h2 className="text-lg font-semibold leading-tight">{board.title}</h2>
+                    <p className="mt-1 text-xs font-mono text-white/50">{board.owner} / #{board.number}</p>
+                  </div>
+                  <a href={board.url} target="_blank" rel="noreferrer" className="text-white/60 hover:text-white">
+                    <IconExternalLink className="h-4 w-4" />
+                  </a>
+                </div>
+
+                {!board.hasAccess && board.error ? (
+                  <p className="mt-4 text-sm text-red-200">{board.error}</p>
+                ) : (
+                  <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                    <Stat label="Total" value={board.stats.total} />
+                    <Stat label="Pending" value={board.stats.pending} />
+                    <Stat label="Assigned" value={board.stats.assignedToViewer} />
+                    <Stat label="Done" value={board.stats.done} />
+                  </div>
+                )}
+
+                <div className="mt-4 flex items-center justify-between gap-2">
+                  <Link
+                    href={`/projects/${encodeURIComponent(board.owner)}/${board.number}`}
+                    className="inline-flex h-8 items-center rounded-md bg-white px-3 text-xs font-medium text-black hover:bg-white/90"
+                  >
+                    Open board
+                  </Link>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeBoard(board)}
+                    disabled={isSaving}
+                    className="text-white/65 hover:text-white hover:bg-white/10 cursor-pointer"
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {!isLoading && boards.length === 0 && (
+            <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-8 text-center text-white/60">
+              No boards added yet. Paste a GitHub project URL to get started.
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/20 p-2">
+      <p className="text-white/45">{label}</p>
+      <p className="mt-1 text-base font-semibold text-white">{value}</p>
+    </div>
+  )
+}

--- a/components/home/top-nav.tsx
+++ b/components/home/top-nav.tsx
@@ -1,4 +1,8 @@
+"use client"
+
+import Link from "next/link"
 import Image from "next/image"
+import { usePathname } from "next/navigation"
 import type { Session } from "next-auth"
 import { signOut } from "next-auth/react"
 import { Button } from "@/components/ui/button"
@@ -8,6 +12,8 @@ interface TopNavProps {
 }
 
 export function TopNav({ session }: TopNavProps) {
+  const pathname = usePathname()
+
   return (
     <nav className="w-full flex justify-between items-center mb-16 md:mb-24 animate-in fade-in slide-in-from-top-4 duration-700">
       <div className="flex items-center gap-1.5 group cursor-default">
@@ -21,6 +27,20 @@ export function TopNav({ session }: TopNavProps) {
       </div>
       {session && (
         <div className="flex items-center gap-2 sm:gap-3">
+          <div className="flex items-center rounded-lg border border-white/10 bg-white/5 p-1">
+            <Link
+              href="/"
+              className={`px-2 py-1 text-xs rounded-md transition-colors ${pathname === "/" ? "bg-white/20 text-white" : "text-white/60 hover:text-white hover:bg-white/10"}`}
+            >
+              Issues
+            </Link>
+            <Link
+              href="/projects"
+              className={`px-2 py-1 text-xs rounded-md transition-colors ${pathname?.startsWith("/projects") ? "bg-white/20 text-white" : "text-white/60 hover:text-white hover:bg-white/10"}`}
+            >
+              Projects
+            </Link>
+          </div>
           <div className="flex items-center gap-2">
             {session.user?.image && (
               <Image

--- a/drizzle/migrations/0007_add_pinned_projects.sql
+++ b/drizzle/migrations/0007_add_pinned_projects.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_preferences"
+ADD COLUMN IF NOT EXISTS "pinnedProjects" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1771012800000,
       "tag": "0006_create_analytics_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1771153200000,
+      "tag": "0007_add_pinned_projects",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -90,6 +90,7 @@ export const userPreferences = pgTable("user_preferences", {
   lastRepoOwner: text("lastRepoOwner"),
   lastRepoName: text("lastRepoName"),
   pinnedRepos: jsonb("pinnedRepos").$type<Array<{ owner: string; name: string }>>().default([]).notNull(),
+  pinnedProjects: jsonb("pinnedProjects").$type<Array<{ owner: string; number: number; ownerType: "user" | "org" }>>().default([]).notNull(),
   createdAt: timestamp("createdAt", { mode: "date" }).defaultNow().notNull(),
   updatedAt: timestamp("updatedAt", { mode: "date" }).defaultNow().notNull(),
 })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -23,7 +23,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       allowDangerousEmailAccountLinking: true,
       authorization: {
         params: {
-          scope: "repo user:email",
+          scope: "repo user:email read:project",
         },
       },
     }),

--- a/lib/github-projects.ts
+++ b/lib/github-projects.ts
@@ -1,0 +1,321 @@
+import { z } from "zod"
+
+export const ownerTypeSchema = z.enum(["user", "org"])
+
+export const pinnedProjectSchema = z.object({
+  owner: z.string().trim().min(1),
+  number: z.number().int().positive(),
+  ownerType: ownerTypeSchema,
+})
+
+export type PinnedProject = z.infer<typeof pinnedProjectSchema>
+
+export interface ProjectBoardItem {
+  id: string
+  title: string
+  url: string
+  status: string
+  statusType: "done" | "in_progress" | "todo" | "unknown"
+  isPending: boolean
+  isAssignedToViewer: boolean
+  assignees: Array<{ login: string; avatarUrl: string }>
+  repoFullName: string | null
+  contentType: "issue" | "pull_request" | "draft"
+  state: string | null
+  updatedAt: string | null
+}
+
+export interface ProjectBoardData {
+  id: string
+  title: string
+  url: string
+  owner: string
+  number: number
+  ownerType: "user" | "org"
+  viewerLogin: string
+  stats: {
+    total: number
+    pending: number
+    assignedToViewer: number
+    done: number
+  }
+  items: ProjectBoardItem[]
+}
+
+export function normalizePinnedProjects(value: unknown): PinnedProject[] {
+  if (!Array.isArray(value)) return []
+
+  const parsed = value
+    .map((entry) => pinnedProjectSchema.safeParse(entry))
+    .filter((result) => result.success)
+    .map((result) => result.data)
+
+  const unique = new Map<string, PinnedProject>()
+  for (const board of parsed) {
+    unique.set(`${board.owner.toLowerCase()}#${board.number}`, board)
+  }
+
+  return Array.from(unique.values())
+}
+
+export function parseGitHubProjectUrl(value: string): PinnedProject {
+  const raw = value.trim()
+  const parsed = new URL(raw)
+
+  if (parsed.hostname !== "github.com") {
+    throw new Error("Only github.com project URLs are supported.")
+  }
+
+  const match = parsed.pathname.match(/^\/(users|orgs)\/([^/]+)\/projects\/(\d+)\/?$/i)
+  if (!match) {
+    throw new Error("Use a GitHub project URL like https://github.com/users/<owner>/projects/<number>.")
+  }
+
+  const [, ownerScope, owner, number] = match
+  return {
+    owner,
+    number: Number(number),
+    ownerType: ownerScope.toLowerCase() === "orgs" ? "org" : "user",
+  }
+}
+
+const PROJECT_QUERY = `
+query ProjectBoard($owner: String!, $number: Int!) {
+  viewer {
+    login
+  }
+  user(login: $owner) {
+    projectV2(number: $number) {
+      ...ProjectBoardFields
+    }
+  }
+  organization(login: $owner) {
+    projectV2(number: $number) {
+      ...ProjectBoardFields
+    }
+  }
+}
+
+fragment ProjectBoardFields on ProjectV2 {
+  id
+  title
+  url
+  items(first: 100) {
+    nodes {
+      id
+      isArchived
+      fieldValues(first: 20) {
+        nodes {
+          __typename
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            optionId
+            field {
+              ... on ProjectV2SingleSelectField {
+                name
+              }
+            }
+          }
+        }
+      }
+      content {
+        __typename
+        ... on Issue {
+          title
+          url
+          state
+          updatedAt
+          repository {
+            nameWithOwner
+          }
+          assignees(first: 10) {
+            nodes {
+              login
+              avatarUrl
+            }
+          }
+        }
+        ... on PullRequest {
+          title
+          url
+          state
+          updatedAt
+          repository {
+            nameWithOwner
+          }
+          assignees(first: 10) {
+            nodes {
+              login
+              avatarUrl
+            }
+          }
+        }
+        ... on DraftIssue {
+          title
+        }
+      }
+    }
+  }
+}
+`
+
+interface GitHubGraphQLResponse<T> {
+  data?: T
+  errors?: Array<{ message: string }>
+}
+
+interface GraphQLProjectFieldValue {
+  __typename?: string
+  name?: string | null
+  field?: { name?: string | null } | null
+}
+
+interface GraphQLProjectNode {
+  id: string
+  isArchived?: boolean
+  fieldValues?: { nodes?: GraphQLProjectFieldValue[] | null } | null
+  content?: {
+    __typename?: string
+    title?: string | null
+    url?: string | null
+    state?: string | null
+    updatedAt?: string | null
+    repository?: { nameWithOwner?: string | null } | null
+    assignees?: { nodes?: Array<{ login?: string | null; avatarUrl?: string | null }> | null } | null
+  } | null
+}
+
+interface GraphQLProjectResult {
+  viewer?: { login?: string | null } | null
+  user?: { projectV2?: { id: string; title: string; url: string; items?: { nodes?: GraphQLProjectNode[] | null } | null } | null } | null
+  organization?: { projectV2?: { id: string; title: string; url: string; items?: { nodes?: GraphQLProjectNode[] | null } | null } | null } | null
+}
+
+async function queryGitHubGraphQL<T>(accessToken: string, query: string, variables: Record<string, unknown>): Promise<T> {
+  const response = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+      "User-Agent": "Kreeate-Issue-Generator",
+    },
+    cache: "no-store",
+    body: JSON.stringify({ query, variables }),
+  })
+
+  const payload: GitHubGraphQLResponse<T> = await response.json().catch(() => ({}))
+
+  if (!response.ok) {
+    const detail = payload.errors?.map((entry) => entry.message).join("; ")
+    throw new Error(detail || `GitHub GraphQL error: ${response.status}`)
+  }
+
+  if (payload.errors?.length) {
+    throw new Error(payload.errors.map((entry) => entry.message).join("; "))
+  }
+
+  if (!payload.data) {
+    throw new Error("GitHub GraphQL response did not include data.")
+  }
+
+  return payload.data
+}
+
+function deriveStatus(values: GraphQLProjectFieldValue[]): { status: string; statusType: ProjectBoardItem["statusType"] } {
+  const statusField = values.find(
+    (entry) =>
+      entry.__typename === "ProjectV2ItemFieldSingleSelectValue" &&
+      entry.field?.name?.trim().toLowerCase() === "status"
+  )
+
+  const status = statusField?.name?.trim() || "No status"
+  const lower = status.toLowerCase()
+
+  if (["done", "closed", "complete", "completed", "merged", "shipped"].some((token) => lower.includes(token))) {
+    return { status, statusType: "done" }
+  }
+  if (["in progress", "active", "review", "blocked"].some((token) => lower.includes(token))) {
+    return { status, statusType: "in_progress" }
+  }
+  if (["todo", "to do", "backlog", "ready", "next"].some((token) => lower.includes(token))) {
+    return { status, statusType: "todo" }
+  }
+
+  return { status, statusType: "unknown" }
+}
+
+export async function fetchGitHubProjectBoard(
+  accessToken: string,
+  board: Pick<PinnedProject, "owner" | "number"> & Partial<Pick<PinnedProject, "ownerType">>
+): Promise<ProjectBoardData> {
+  const data = await queryGitHubGraphQL<GraphQLProjectResult>(accessToken, PROJECT_QUERY, {
+    owner: board.owner,
+    number: board.number,
+  })
+
+  const projectNode = data.user?.projectV2 || data.organization?.projectV2
+
+  if (!projectNode) {
+    throw new Error("Project board not found or access denied.")
+  }
+
+  const viewerLogin = data.viewer?.login || ""
+  const ownerType: "user" | "org" = data.user?.projectV2 ? "user" : "org"
+  const nodes = projectNode.items?.nodes || []
+
+  const items = nodes.map<ProjectBoardItem>((node) => {
+    const content = node.content
+    const fieldValues = node.fieldValues?.nodes || []
+    const { status, statusType } = deriveStatus(fieldValues)
+
+    const assignees = (content?.assignees?.nodes || [])
+      .map((entry) => ({
+        login: entry.login || "",
+        avatarUrl: entry.avatarUrl || "",
+      }))
+      .filter((entry) => entry.login.length > 0)
+
+    const contentType: ProjectBoardItem["contentType"] =
+      content?.__typename === "Issue" ? "issue" : content?.__typename === "PullRequest" ? "pull_request" : "draft"
+
+    const state = content?.state || null
+    const closedState = state === "CLOSED" || state === "MERGED"
+    const pending = !node.isArchived && statusType !== "done" && !closedState
+    const assignedToViewer = viewerLogin.length > 0 && assignees.some((entry) => entry.login.toLowerCase() === viewerLogin.toLowerCase())
+
+    return {
+      id: node.id,
+      title: content?.title?.trim() || "Untitled",
+      url: content?.url || projectNode.url,
+      status,
+      statusType,
+      isPending: pending,
+      isAssignedToViewer: assignedToViewer,
+      assignees,
+      repoFullName: content?.repository?.nameWithOwner || null,
+      contentType,
+      state,
+      updatedAt: content?.updatedAt || null,
+    }
+  })
+
+  const stats = {
+    total: items.length,
+    pending: items.filter((item) => item.isPending).length,
+    assignedToViewer: items.filter((item) => item.isAssignedToViewer).length,
+    done: items.filter((item) => item.statusType === "done").length,
+  }
+
+  return {
+    id: projectNode.id,
+    title: projectNode.title,
+    url: projectNode.url,
+    owner: board.owner,
+    number: board.number,
+    ownerType,
+    viewerLogin,
+    stats,
+    items,
+  }
+}

--- a/types/projects.ts
+++ b/types/projects.ts
@@ -1,0 +1,45 @@
+export interface ProjectBoardStats {
+  total: number
+  pending: number
+  assignedToViewer: number
+  done: number
+}
+
+export interface SavedProjectBoardCard {
+  owner: string
+  number: number
+  ownerType: "user" | "org"
+  title: string
+  url: string
+  stats: ProjectBoardStats
+  lastUpdatedAt: string | null
+  hasAccess: boolean
+  error: string | null
+}
+
+export interface ProjectBoardItem {
+  id: string
+  title: string
+  url: string
+  status: string
+  statusType: "done" | "in_progress" | "todo" | "unknown"
+  isPending: boolean
+  isAssignedToViewer: boolean
+  assignees: Array<{ login: string; avatarUrl: string }>
+  repoFullName: string | null
+  contentType: "issue" | "pull_request" | "draft"
+  state: string | null
+  updatedAt: string | null
+}
+
+export interface ProjectBoard {
+  id: string
+  title: string
+  url: string
+  owner: string
+  number: number
+  ownerType: "user" | "org"
+  viewerLogin: string
+  stats: ProjectBoardStats
+  items: ProjectBoardItem[]
+}


### PR DESCRIPTION
## Summary
- add a new Projects area where users can save multiple GitHub project board URLs and open each board via dynamic routes
- add GitHub GraphQL-backed API routes for board list cards and board detail data, including pending/assigned/done stats
- persist saved boards in user preferences with a new `pinnedProjects` column and migration

## Notes
- known follow-up: users with older OAuth sessions may hit GitHub GraphQL 401/scope errors until they re-consent with `read:project`